### PR TITLE
feat: add config option to set gre key

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,7 @@ type Defaults struct {
 	SpoofReplySrc       *bool   `yaml:"spoof_reply_src"`
 	SrcRange            *string `yaml:"src_range"`
 	TimeoutMS           *uint64 `yaml:"timeout"`
+	KeyId               *uint32 `yaml:"key_id"`
 }
 
 // Class reperesnets a traffic class in the config file


### PR DESCRIPTION
This is meant to identify the correct tunnel on Cisco devices
that support gre multipoint tunnels.

Signed-off-by: Peter Lieven <pl@kamp.de>