### PR TITLE
fix(collector): use configured path name in metrics

### DIFF
--- a/pkg/prober/collector.go
+++ b/pkg/prober/collector.go
@@ -1,7 +1,6 @@
 package prober
 
 import (
-	"strings"
 	"time"
 
 	"github.com/exaring/matroschka-prober/pkg/measurement"
@@ -41,7 +40,7 @@ func (p *Prober) labels() []string {
 
 func (p *Prober) labelValues() []string {
 	ret := make([]string, 0, 1)
-	ret = append(ret, strings.Join(p.path.Hops, "-"))
+	ret = append(ret, p.path.Name)
 	return ret
 }
 


### PR DESCRIPTION
use the path name from the path config and not an aritifical
name built from the passed hops as path tag.

Signed-off-by: Peter Lieven <pl@kamp.de>