### PR TITLE
fix: leak in MeasurementsDB

### DIFF
--- a/pkg/prober/sender.go
+++ b/pkg/prober/sender.go
@@ -39,8 +39,9 @@ func (p *Prober) sender() {
 
 		p.transitProbes.add(&pr)
 
-		tsAligned := pr.Ts - (pr.Ts % (int64(*p.path.MeasurementLengthMS) * int64(time.Millisecond)))
-		p.measurements.AddSent(tsAligned)
+		measurementTime := (int64(*p.path.MeasurementLengthMS) * int64(time.Millisecond))
+		tsAligned := pr.Ts - (pr.Ts % measurementTime)
+		p.measurements.AddSentAndRemoveOlder(tsAligned, tsAligned - 2 * measurementTime)
 
 		srcAddr := p.getSrcAddr(seq)
 		dstAddr := p.hops[0].getAddr(seq)


### PR DESCRIPTION
we constantly add probes to a MeasurementsDB, but we never remove old entries.
Hook the remove process to the adding of a new probe entry to the DB when
we already hold the write lock.

Signed-off-by: Peter Lieven <pl@kamp.de>